### PR TITLE
fix: corrijido o funcionamento da função

### DIFF
--- a/source/cadastro.c
+++ b/source/cadastro.c
@@ -18,12 +18,6 @@ int cadastro(Usuario *ptrUsuario){
     ptrUsuario->saldoRIPPLE = 0.0;
     ptrUsuario->saldoReais = 0.0;
 
-    if(verificaCPF(ptrUsuario))
-    {
-        fclose(ptrArquivo);
-        return 1;
-    }
-
     fwrite(ptrUsuario, bytes, 1, ptrArquivo);
     fclose(ptrArquivo);
 


### PR DESCRIPTION
Agora a função `cadastro()` irá apenas cadastrar, e não verificar o cpf.